### PR TITLE
Add reusable workflow parts that can (optionally) be used by projects for luarocks deploy

### DIFF
--- a/workflows/list_affected_rockspecs.yml
+++ b/workflows/list_affected_rockspecs.yml
@@ -1,0 +1,26 @@
+name: List affected rockspecs
+
+on:
+  workflow_call:
+    outputs:
+      rockspecs:
+        value: ${{ jobs.affected.outputs.rockspecs }}
+
+jobs:
+  affected:
+    name: Find edited rockspecs
+    runs-on: ubuntu-20.04
+    outputs:
+      rockspecs: '["${{ steps.changed-files.outputs.all_modified_files }}"]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - id: changed-files
+        uses: tj-actions/changed-files@v18
+        with:
+          files: |
+            *.rockspec
+            rockspecs/*.rockspec
+          separator: '", "'

--- a/workflows/test_build_rock.yml
+++ b/workflows/test_build_rock.yml
@@ -1,0 +1,45 @@
+name: Test build rock
+
+on:
+  workflow_call:
+    inputs:
+      rockspecs:
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: Test build rockspec
+    strategy:
+      fail-fast: false
+      matrix:
+        # Upstream Issue: https://github.com/leafo/gh-actions-luarocks/issues/8
+        luaVersion: [ "5.4", "5.3", "5.2", "5.1" ] #, "luajit", "luajit-openresty"]
+        # luarocksVersion: [ "3.1.3" ] # , "2.4.2"]
+        rockspec: ${{ fromJSON(inputs.rockspecs) }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup ‘lua’
+        uses: leafo/gh-actions-lua@v9
+        with:
+          luaVersion: ${{ matrix.luaVersion }}
+      - name: Setup ‘luarocks’
+        uses: leafo/gh-actions-luarocks@v4
+        # with:
+          # luarocksVersion: ${{ matrix.luarocksVersion }}
+      - name: Confirm dev rockspec(s) build
+        if: ${{ !startsWith(matrix.rockspec, 'rockspecs/') }}
+        run: |
+          args="--lua-version ${{ matrix.luaVersion }}"
+          luarocks make --pack-binary-rock $args -- ${{ matrix.rockspec }}
+      - name: Confirm tagged rockspec(s) build
+        if: ${{ startsWith(matrix.rockspec, 'rockspecs/') }}
+        run: |
+          args="--lua-version ${{ matrix.luaVersion }}"
+          set -euo pipefail
+          git tag | grep -Fxq ${{ github.ref_name}} || args+=" --branch ${{ github.ref_name }}"
+          luarocks build --pack-binary-rock $args -- ${{ matrix.rockspec }}

--- a/workflows/upload_to_luarocks.yml
+++ b/workflows/upload_to_luarocks.yml
@@ -1,0 +1,45 @@
+name: Upload to LuaRocks
+
+on:
+  workflow_call:
+    inputs:
+      rockspecs:
+        required: true
+        type: string
+    secrets:
+      apikey:
+        required: true
+
+jobs:
+  upload:
+    name: Build rocks and upload to LuaRocks
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        rockspec: ${{ fromJSON(inputs.rockspecs) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup ‘lua’
+        uses: leafo/gh-actions-lua@v9
+      - name: Setup ‘luarocks’
+        uses: leafo/gh-actions-luarocks@v4
+      - name: Setup dependencies
+        run: |
+          luarocks install dkjson
+      - name: Parse tag to version
+        id: parsetag
+        run: echo "::set-output name=version::$(sed 's/^v//' <<< ${{ github.ref_name }})"
+      - name: Upload dev rockspec(s) to luarocks
+        # Upload dev rockspecs any time they are touched
+        if: ${{ !startsWith(matrix.rockspec, 'rockspecs/') }}
+        run: |
+          args="--temp-key ${{ secrets.apikey }} --force --skip-pack"
+          luarocks upload $args -- ${{ matrix.rockspec }}
+      - name: Upload tag rockspec(s) to luarocks
+        # Only upsload stable rockspecs if the file was touched AND we're processing a matching git tag
+        if: ${{ startsWith(matrix.rockspec, 'rockspecs/') && contains(matrix.rockspec, steps.parsetag.outputs.version) }}
+        run: |
+          args="--temp-key ${{ secrets.apikey }}"
+          luarocks upload $args -- ${{ matrix.rockspec }}


### PR DESCRIPTION
This is basically a straight copy of what I have in moon-sand right now which was already the logic I like and should work as-is for what @mwild1 [requested for luaexpat](https://github.com/lunarmodules/luaexpat/issues/5#issuecomment-1073805661). As such it seems like a good place to start.

This isn't a complete workflow, it is just some reusable parts that can easily be assembled into a workflow using the new dispatcher features.