### PR TITLE
Refactor rockspec testing and publishing

### DIFF
--- a/.github/workflows/list_affected_rockspecs.yml
+++ b/.github/workflows/list_affected_rockspecs.yml
@@ -21,10 +21,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - id: changed-files
-        uses: tj-actions/changed-files@v28
+        uses: tj-actions/changed-files@v29.0.1
         with:
+          since_last_remote_commit: true
           files: |
             *.rockspec
             rockspecs/*.rockspec

--- a/.github/workflows/test_build_rock.yml
+++ b/.github/workflows/test_build_rock.yml
@@ -33,11 +33,25 @@ jobs:
         uses: leafo/gh-actions-luarocks@v4
         with:
           luarocksVersion: ${{ matrix.luarocksVersion }}
+      - name: Monkey-patch rockspec source.url to assure testing against relevant repo fork
+        run: |
+          sed -i -e '/^\s*url/s!=.*!= "${{ github.repositoryURL }}",!' -e 's!git:!git+https:!' ${{ matrix.rockspec }}
       - name: Confirm dev rockspec(s) build
         if: ${{ !startsWith(matrix.rockspec, 'rockspecs/') && !startsWith(matrix.luarocksVersion, '2') }}
         run: |
           args="--lua-version ${{ matrix.luaVersion }}"
           luarocks make --pack-binary-rock $args -- ${{ matrix.rockspec }}
+      - name: Parse semver and check for matching tag of touched rockspec
+        id: parsetag
+        run: |
+          semver=$(rev <<< "${{ matrix.rockspec }}" | cut -d- -f2 | rev)
+          echo "::set-output name=semver::$semver"
+          tag=$(git tag | grep -Ex "v?${semver//\\./\\\\.}" ||:)
+          echo "::set-output name=tag::$tag"
+      - name: Monkey-patch rockspec source.tag in release rockspecs if tag not present
+        if: ${{ startsWith(matrix.rockspec, 'rockspecs/') && !steps.parsetag.outputs.tag }}
+        run: |
+          sed -i -e '/^\s*tag/d' -e '/^\s*branch/s!=.*!= "${{ github.ref_name }}",!' ${{ matrix.rockspec }}
       - name: Confirm tagged rockspec(s) build
         if: ${{ startsWith(matrix.rockspec, 'rockspecs/') }}
         run: |

--- a/.github/workflows/test_build_rock.yml
+++ b/.github/workflows/test_build_rock.yml
@@ -57,5 +57,4 @@ jobs:
         run: |
           args="--lua-version ${{ matrix.luaVersion }}"
           set -euo pipefail
-          git tag | grep -Fxq ${{ github.ref_name}} || args+=" --branch ${{ github.ref_name }}"
           luarocks build --pack-binary-rock $args ${{ matrix.rockspec }}

--- a/.github/workflows/upload_to_luarocks.yml
+++ b/.github/workflows/upload_to_luarocks.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Setup ‘lua’
         uses: leafo/gh-actions-lua@v9
       - name: Setup ‘luarocks’
@@ -28,18 +30,22 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install dkjson
-      - name: Parse tag to version
+      - name: Parse semver and check for matching tag of touched rockspec
         id: parsetag
-        run: echo "::set-output name=version::$(sed 's/^v//' <<< ${{ github.ref_name }})"
-      - name: Upload dev rockspec(s) to luarocks
-        # Upload dev rockspecs any time they are touched
+        run: |
+          semver=$(rev <<< "${{ matrix.rockspec }}" | cut -d- -f2 | rev)
+          echo "::set-output name=semver::$semver"
+          tag=$(git tag | grep -Ex "v?${semver//\\./\\\\.}" ||:)
+          echo "::set-output name=tag::$tag"
+      - name: Upload dev rockspec to luarocks
+        # Upload dev rockspecs any time they{ are touched
         if: ${{ !startsWith(matrix.rockspec, 'rockspecs/') }}
         run: |
           args="--temp-key ${{ secrets.apikey }} --force --skip-pack"
           luarocks upload $args -- ${{ matrix.rockspec }}
-      - name: Upload tag rockspec(s) to luarocks
-        # Only upload stable rockspecs if the file was touched AND we're processing a matching git tag
-        if: ${{ startsWith(matrix.rockspec, 'rockspecs/') && contains(matrix.rockspec, steps.parsetag.outputs.version) }}
+      - name: Upload release rockspec to luarocks
+        # Only upload stable rockspecs if the file was touched AND a matching tag exists
+        if: ${{ startsWith(matrix.rockspec, 'rockspecs/') && steps.parsetag.outputs.tag }}
         run: |
           args="--temp-key ${{ secrets.apikey }}"
           luarocks upload $args -- ${{ matrix.rockspec }}


### PR DESCRIPTION
Closes #4

This completely changes the logic of what gets tested and published when. It *mostly* gets around the catch 22 problem by allowing rockspecs to be tested before their related releases are tagged, but with a caveat: if the tag has not been released yet then the `source.tag` field is dropped and the `source.branch` field is set to the currently tested branch. Additionally the `source.url` field us changed to the source repository, so if a fork is being tested it actually builds from that fork no the canonical one.

This means *most* aspects of the rockspec get tested, but not the actual final rockspec text because the final `source.<>` fields are not used unless the tag actually exists.

Additionally it looses the check on affected rockspecs so not just the last commit is reviewed but all commits since the last push or base branch.

Finally the check on whether to publish or not is loosened to just be a version match, the rockrel is ignored. This means that instead of having to be *on* a tagged commit to publish, any rockspecs committed as the tagged commit **or thereafter** are eligible for publishing (once). The rational for this is that we tag only the semver part of a release (e.g. `v1.2.3` but not the rockrel). In the event that a release goes sideways and a rockrel bump is needed with no changes to the project sources except the actual rockspec, then you can create a rockspec with the rockrel bump and commit it and it will get published with no further tagging action required. As long as hag `v?1.2.3` exists then rockspec `foo-1.2.3-5.rockspec` will get published.
