### PR TITLE
Add Dependabot for GitHub Actions and pin workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly
+    cooldown:  # https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html
+      default-days: 7

--- a/.github/workflows/docker_ghcr_deploy.yml
+++ b/.github/workflows/docker_ghcr_deploy.yml
@@ -19,17 +19,17 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           registry: ghcr.io
           username: ${{ inputs.username }}
           password: ${{ secrets.token }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
           push: ${{ github.ref_name == 'master' || github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/list_affected_rockspecs.yml
+++ b/.github/workflows/list_affected_rockspecs.yml
@@ -19,7 +19,7 @@ jobs:
         }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - id: changed-files

--- a/.github/workflows/test_build_rock.yml
+++ b/.github/workflows/test_build_rock.yml
@@ -31,15 +31,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - name: Setup ‘lua’
-        uses: leafo/gh-actions-lua@v11
+        uses: leafo/gh-actions-lua@8aace3457a2fcf3f3c4e9007ecc6b869ff6d74d6 # v11
         with:
           luaVersion: ${{ matrix.luaVersion }}
       - name: Setup ‘luarocks’
-        uses: leafo/gh-actions-luarocks@v5
+        uses: leafo/gh-actions-luarocks@4c082a5fad45388feaeb0798dbd82dbd7dc65bca # v5
         with:
           luarocksVersion: ${{ matrix.luarocksVersion }}
       - name: Monkey-patch rockspec source.url to assure testing against relevant repo fork

--- a/.github/workflows/upload_to_luarocks.yml
+++ b/.github/workflows/upload_to_luarocks.yml
@@ -20,13 +20,13 @@ jobs:
         rockspec: ${{ fromJSON(inputs.rockspecs) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - name: Setup ‘lua’
-        uses: leafo/gh-actions-lua@v11
+        uses: leafo/gh-actions-lua@8aace3457a2fcf3f3c4e9007ecc6b869ff6d74d6 # v11
       - name: Setup ‘luarocks’
-        uses: leafo/gh-actions-luarocks@v5
+        uses: leafo/gh-actions-luarocks@4c082a5fad45388feaeb0798dbd82dbd7dc65bca # v5
       - name: Setup dependencies
         run: |
           luarocks install dkjson


### PR DESCRIPTION
This PR adds Dependabot support for GitHub Actions and pins workflow action references to commit SHAs.

Commits:
1. Add Dependabot config for GitHub Actions (modeled after terminal.lua)
2. Pin workflow actions to commit SHAs and include version/tag comments after each SHA so Dependabot can update both.